### PR TITLE
update `p9_wire_format_derive` to `syn` 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.2.3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -61,18 +61,7 @@ checksum = "401797fe7833d72109fedec6bfcbe67c0eed9b99772f26eb8afd261f0abc6fd3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.27",
-]
-
-[[package]]
-name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
+ "syn",
 ]
 
 [[package]]

--- a/p9_wire_format_derive/Cargo.toml
+++ b/p9_wire_format_derive/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/google/rust-p9"
 readme = "../README.md"
 
 [dependencies]
-syn = "^1"
+syn = "2"
 quote = "^1"
 proc-macro2 = "^1"
 


### PR DESCRIPTION
Android and crosvm both updated to syn 2. This helps trim build deps a bit.