### PR TITLE
Increase buffer size of ReadDir to permit larger file names.

### DIFF
--- a/src/server/read_dir.rs
+++ b/src/server/read_dir.rs
@@ -45,7 +45,10 @@ pub struct DirEntry<'r> {
 }
 
 pub struct ReadDir<'d, D> {
-    buf: [u8; 256],
+    // This buffer is double the size of NAME_MAX because
+    // getdents64 chokes (EINVAL) with a buffer sized
+    // NAME MAX on file names close to NAME_MAX in length.
+    buf: [u8; 512],
     dir: &'d mut D,
     current: usize,
     end: usize,
@@ -118,7 +121,7 @@ pub fn read_dir<D: AsRawFd>(dir: &mut D, offset: libc::off64_t) -> Result<ReadDi
     syscall!(unsafe { libc::lseek64(dir.as_raw_fd(), offset, libc::SEEK_SET) })?;
 
     Ok(ReadDir {
-        buf: [0u8; 256],
+        buf: [0u8; 512],
         dir,
         current: 0,
         end: 0,


### PR DESCRIPTION
Experimentally, very lengthy file names somehow do not fit in the 256 character buffer, even though they should (NAME_MAX).  Adding 8 or 16 characters to the size of the buffer I tried, and it did not work. So I doubled the character buffer size to be on the safe side, and this worked.  Noted that I tried 384 bytes too, and this worked, but it is not clear to me if (counting getdents64 offsets) that would be safe in the presence of two files close to NAME_MAX consecutively in a directory listing, so I chose the safe option instead.