### PR TITLE
p9_wire_format_derive: update to Rust 2021 edition

### DIFF
--- a/p9_wire_format_derive/Cargo.toml
+++ b/p9_wire_format_derive/Cargo.toml
@@ -2,6 +2,7 @@
 name = "p9_wire_format_derive"
 version = "0.2.3"
 authors = ["The ChromiumOS Authors"]
+edition = "2021"
 license = "BSD-3-Clause"
 description = "Supporting proc-macro for the `p9` crate."
 repository = "https://github.com/google/rust-p9"

--- a/p9_wire_format_derive/src/lib.rs
+++ b/p9_wire_format_derive/src/lib.rs
@@ -8,17 +8,11 @@
 
 #![recursion_limit = "256"]
 
-extern crate proc_macro;
-extern crate proc_macro2;
-
-#[macro_use]
-extern crate quote;
-
-#[macro_use]
-extern crate syn;
-
 use proc_macro2::Span;
 use proc_macro2::TokenStream;
+use quote::quote;
+use quote::quote_spanned;
+use syn::parse_macro_input;
 use syn::spanned::Spanned;
 use syn::Data;
 use syn::DeriveInput;
@@ -49,13 +43,12 @@ fn p9_wire_format_inner(input: DeriveInput) -> TokenStream {
     let scope = Ident::new(&scope, Span::call_site());
     quote! {
         mod #scope {
-            extern crate std;
-            use self::std::io;
-            use self::std::result::Result::Ok;
+            use ::std::io;
+            use ::std::result::Result::Ok;
 
             use super::#container;
 
-            use protocol::WireFormat;
+            use crate::protocol::WireFormat;
 
             impl WireFormat for #container {
                 fn byte_size(&self) -> u32 {
@@ -158,6 +151,8 @@ fn decode_wire_format(data: &Data, container: &Ident) -> TokenStream {
 
 #[cfg(test)]
 mod tests {
+    use syn::parse_quote;
+
     use super::*;
 
     #[test]
@@ -247,13 +242,12 @@ mod tests {
 
         let expected = quote! {
             mod wire_format_niijima_先輩 {
-                extern crate std;
-                use self::std::io;
-                use self::std::result::Result::Ok;
+                use ::std::io;
+                use ::std::result::Result::Ok;
 
                 use super::Niijima_先輩;
 
-                use protocol::WireFormat;
+                use crate::protocol::WireFormat;
 
                 impl WireFormat for Niijima_先輩 {
                     fn byte_size(&self) -> u32 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,6 @@
 
 #![cfg(unix)]
 
-extern crate libc;
-
-#[macro_use]
-extern crate p9_wire_format_derive;
-
 mod protocol;
 mod server;
 

--- a/src/protocol/messages.rs
+++ b/src/protocol/messages.rs
@@ -10,6 +10,8 @@ use std::mem;
 use std::string::String;
 use std::vec::Vec;
 
+use p9_wire_format_derive::P9WireFormat;
+
 use crate::protocol::wire_format::Data;
 use crate::protocol::wire_format::WireFormat;
 

--- a/src/protocol/wire_format.rs
+++ b/src/protocol/wire_format.rs
@@ -198,6 +198,8 @@ mod test {
     use std::mem;
     use std::string::String;
 
+    use p9_wire_format_derive::P9WireFormat;
+
     use super::*;
 
     #[test]


### PR DESCRIPTION
The main p9 crate had edition set, but the derive crate did not.

Fixes a compiler warning: "no edition set: defaulting to the 2015 edition while the latest is 2021"