### PR TITLE
p9_wire_format_derive: drop proc_macro function def for tests

### DIFF
--- a/p9_wire_format_derive/src/lib.rs
+++ b/p9_wire_format_derive/src/lib.rs
@@ -8,6 +8,11 @@
 
 #![recursion_limit = "256"]
 
+// Non-cargo build systems may not automatically include this for tests, so
+// explicitly include it. We could also `#[cfg(not(test))]` `p9_wire_format`, but
+// that leads to warnings about unused imports.
+extern crate proc_macro;
+
 use proc_macro2::Span;
 use proc_macro2::TokenStream;
 use quote::quote;


### PR DESCRIPTION
When trying to update this crate, the build broke because `proc_macro` wasn't defined. It seems cargo will silently inject the `proc_macro` crate for tests of `proc_macro` crates, but this is not something that _all_ non-Cargo build systems do.

I originally `cfg(not(test))`'ed the function, but noticed warnings when `cargo test`ing. Explicit `extern crate` seems like the least bad option.

Bug: 464046805